### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,7 @@ slowly as well. The right side of the moving track does not have
 great change.
 
 Part 2
-Symplectic Euler method gives the numerical solution which is a closed ellipse (The blue circle in the above graph) which
-shows the motion and position conserves with the time changing. In the other world, the moving track of this planet always
-follows a fixed track all the time. The angular momentum of this method conserves at 0.8 with the increasing of t. Overall, the
-Hamiltonian of this method conserves at -0.5 with really tiny oscillation when t increases.
-The numerical solution from Standard Euler's method does not convers. From the part 2, it also tells the Hamiltonian or angular
-momentum by Standard Euler's method do not conserve.
+Symplectic Euler method achieves a closed ellipse solution which illustrates the planet’s motion and position are always conserved. It also proves that the planet has fixed traveling track which is not affected by time. This solution shows the planet’s angular momentum conserves 0.8 and Hamiltonian conserves at -0.5 with small oscillation. Standard Euler's method obtains the numerical solution which does not conserve. The proof in part 2 also shows that the resulted Hamiltonian and angular momentum of the planet does not conserve.
+
 (In the 3 above graph, blue plot represents Symplectic Euler method and the red plot representes standard Euler's method. I
 combined them together to bring a great comparison.)


### PR DESCRIPTION
In the technical writing, the vocabulary should be formal and proper. The document contains some improper verbs such as "give" and "make".  This revision replaced all informal vocabulary and fixed force cohesion problems. For example, "In the other world, the moving track of this planet always
-follows a fixed track all the time" can be combined with the previous sentence. 